### PR TITLE
Add getting key value in hex format

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -4,7 +4,7 @@ import "github.com/2nd/lmdb-cli/core"
 
 var helpText = []byte(`
   del KEY        - removes the key/value
-  get KEY FORMAT - gets the value. FORMAT is optional or 'json'
+  get KEY FORMAT - gets the value. FORMAT is optional or 'json' or 'hex'
   set KEY        - creates or overwrites the key with the specified value
                    (aliases: put)
   exists KEY     - checks if the key exists


### PR DESCRIPTION
Sometimes values are not stored in text/json formats, but in binary format, so outputing in hex format may be useful.

Example output:
```
	// 00000000  47 6f 20 69 73 20 61 6e  20 6f 70 65 6e 20 73 6f  |Go is an open so|
	// 00000010  75 72 63 65 20 70 72 6f  67 72 61 6d 6d 69 6e 67  |urce programming|
	// 00000020  20 6c 61 6e 67 75 61 67  65 2e                    | language.|
```